### PR TITLE
Fix pixel access for image inversion

### DIFF
--- a/src/framework/image.cpp
+++ b/src/framework/image.cpp
@@ -309,7 +309,7 @@ bool Image::SaveTGA(const char* filename)
 	for(unsigned int y = 0; y < height; ++y)
 		for(unsigned int x = 0; x < width; ++x)
 		{
-			Color c = pixels[y*width+x];
+			Color c = pixels[(height - y - 1) * width + x];
 			unsigned int pos = (y*width+x)*3;
 			bytes[pos+2] = c.r;
 			bytes[pos+1] = c.g;


### PR DESCRIPTION
LoadTGA: when loading, the function reads data from position y in the file but writes it to position height - y - 1 in the image. This inverts the Y-axis during loading.

SaveTGA: when saving, the function reads from position y in the image and writes it to position y in the file. There is no Y-axis inversion during saving. I changed this line       Color c = pixels[y * width + x]; to this one Color c = pixels[(height - y - 1) * width + x]; and now loads the image correctly.